### PR TITLE
Fix firefox image caching error

### DIFF
--- a/src/pages/MovieDetails.jsx
+++ b/src/pages/MovieDetails.jsx
@@ -61,11 +61,12 @@ const MovieDetails = () => {
         <section className="w-screen h-screen overflow-hidden relative">
           <img
             alt="Image backdrop"
-            src={
-              movieDetails.backdrop_path == null
-                ? noBackdropPoster
-                : `https://image.tmdb.org/t/p/original/${movieDetails.backdrop_path}`
-            }
+            src={`
+              ${
+                movieDetails.backdrop_path == null
+                  ? noBackdropPoster
+                  : `https://image.tmdb.org/t/p/original/${movieDetails.backdrop_path}`
+              }?${Math.random()}`}
             className="w-full h-full object-cover"
             onLoad={() => setImageLoaded(true)}
           />


### PR DESCRIPTION
## What does this PR do?
- [x] It updates the image element in the `MovieDetails` page to fix the problem of caching the former movie backdrop image when a new movie has been requested for via the API.